### PR TITLE
Add ability to use directory or archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,34 @@ to build the application:
 cargo build --release # <cargo build options...>
 ```
 
+## Options
+
+There are a few options that you can supply to the service. The default behaviour without these options is to autodetect the archive type, and in the case where a directory is found with a `Cargo.toml` in the root, then the default compression of `gzip` is used.
+
+- `<param name="strategy">vendor</param>`
+
+The default here is `vendor` which will use `cargo vendor` to fetch the crate dependencies. There are currently no alternatives to `vendor`.
+
+- `<param name="archive">archivename.tar.gz</param>`
+
+The name of the required archive. The option is used in the case where there may be multiple archives available in the package build. This can also be used to specify a directory - useful in the case of using the `obs_scm` service.
+
+- `<param name="compression">xz</param>`
+
+The compression to use for the `vendor.tar`. If the option is not supplied it will default to `gz` or the same compression as the source archive. Available compressions are those supported by `tar`.
+
+#### Example
+
+```
+<services>
+  <service name="cargo_vendor" mode="disabled">
+    <param name="strategy">vendor</param>
+    <param name="archive">some_git_repo</param>
+    <param name="compression">xz</param>
+  </service>
+</services>
+```
+
 ## Transition note
 
 Until `obs-service-cargo_vendor` is available on [OBS](https://build.opensuse.org),

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Follow this steps when creating a new RPM package for a Rust application:
 > where the RPM packaging uses spec file `app.spec`.
 >
 > The archive name can alternatively be specified using service parameter `archive`.
+>
+> In some instances a package may be using SCM, in which case a directory is used rather than an archive, `cargo_vendor` can also handle this if archive name and compression args are supplied, eg:
+>
+> `<param name="archive">tokei</param>`
+>
+> `<param name="archive">tokei</param>`
+>
+> `cargo_vendor` will also auto find and use the first directory containing a `Cargo.toml` if the archive args is not used.
 
 2. Run `osc` command locally:
 
@@ -55,10 +63,11 @@ $ osc add vendor.tar.gz
 ```
 
 4. In `app.spec`:
- - include the tarball as a source along with the main source tarball:
+ - include the tarball as a source, along with the cargo_config and the main source tarball:
 ```
 Source0:        app-%{version}.tar.xz
 Source1:        vendor.tar.xz
+Source2:        cargo_config
 ```
  - At the `%prep` step, extract the vendor archive inside the app source code:
 ```
@@ -66,23 +75,17 @@ Source1:        vendor.tar.xz
 %setup -q -a1
 ```
 
-Create a `$CARGO_HOME` directory, including a `config` file in it with the configuration
+Create a `$CARGO_HOME` directory, including the `config` file in it with the configuration
 for the vendored sources:
 ```
 mkdir .cargo
-cat >.cargo/config <<EOF
-[source.crates-io]
-registry = 'https://github.com/rust-lang/crates.io-index'
-replace-with = 'vendored-sources'
-[source.vendored-sources]
-directory = './vendor'
-EOF
+cp %{SOURCE2} .cargo/config
 ```
 
 - At the `%build` step, export the previously created `$CARGO_HOME` and use `cargo build`
 to build the application:
 ```
-cargo build --path `pwd` # <cargo build options...>
+cargo build --release # <cargo build options...>
 ```
 
 ## Transition note

--- a/cargo_vendor
+++ b/cargo_vendor
@@ -57,6 +57,31 @@ args = parser.parse_args()
 
 outdir = args.outdir
 
+vendor_example = """
+Your spec file should be modified per the following example:
+
+---BEGIN---
+%global rustflags '-Clink-arg=-Wl,-z,relro,-z,now'
+
+Source1:    vendor.tar.xz
+Source2:    cargo_config
+
+%prep
+%setup -qa1
+mkdir .cargo
+cp %{SOURCE2} .cargo/config
+
+%build
+RUSTFLAGS=%{rustflags} cargo build --release
+
+%install
+RUSTFLAGS=%{rustflags} cargo install --root=%{buildroot}%{_prefix} --path .
+---END---
+
+WARNING: To avoid cargo install rebuilding the binary in the install stage
+         all environment variables must be the same as in the build stage.
+"""
+
 
 def get_archive_extension():
     if args.compression not in tarfile.TarFile.OPEN_METH:
@@ -71,6 +96,13 @@ def get_archive_extension():
 
 archive_ext = get_archive_extension()
 vendor_tarname = f"vendor.{archive_ext}"
+
+
+def find_file(path, filename):
+    for root, dirs, files in os.walk(path):
+        if filename in files:
+            print(os.path.join(root, filename))
+            return os.path.join(root, filename)
 
 
 def archive_autodetect():
@@ -91,8 +123,13 @@ def archive_autodetect():
         pattern = f"{spec.stem}*.{archive_ext}"
         archive = next(reversed(sorted(Path(spec_dir).glob(pattern))), None)
     if not archive:
-        log.error(f"Archive autodetection found no matching archive under {cwd}")
-        exit(1)
+        archive = find_file(cwd, "Cargo.toml")
+        app_dir = os.path.basename(os.path.normpath(os.path.dirname(archive)))
+        if app_dir:
+            return app_dir
+        else:
+            log.error(f"Archive autodetection found no matching archive under {cwd}")
+            exit(1)
     else:
         log.info(f"Archive autodetected at {archive}")
         # Check that app.spec Version: directive value
@@ -117,23 +154,20 @@ def archive_autodetect():
 archive = args.archive or archive_autodetect()
 log.info(f"Using archive {archive}")
 
-basename = archive.replace(f".{archive_ext}", "")
-
-
 def extract(filename, dir):
     if filename.endswith(f".{archive_ext}"):
         tar = tarfile.open(filename)
         tar.extractall(path=dir)
         tar.close()
     else:
-        log.info(f"Unsupported archive file format for {filename}")
-        exit(1)
-
-
-def find_file(path, filename):
-    for root, dirs, files in os.walk(path):
-        if filename in files:
-            return os.path.join(root, filename)
+        cargo_toml_path = find_file(filename, "Cargo.toml")
+        if cargo_toml_path:
+            log.info(f"Archive {filename} is a directory containing Cargo.toml")
+            log.info(f"Copying {filename} in to {dir}")
+            shutil.copytree(filename, dir+'/'+filename)
+        else:
+            log.info(f"Unsupported archive file format for {filename}")
+            exit(1)
 
 
 def run_cargo(runDirectory, command, argsList=[]):
@@ -141,7 +175,11 @@ def run_cargo(runDirectory, command, argsList=[]):
         log.info(f"Running cargo {command} in directory: {runDirectory}")
         output = check_output(["cargo", command] + argsList, cwd=runDirectory).decode("utf-8").strip()
         if output:
-            log.info(output)
+            log.info(vendor_example)
+            config_file_path = os.path.join(outdir, "cargo_config")
+            config_file = open(config_file_path, 'w')
+            config_file.write(output)
+            config_file.close()
         return True
     except CalledProcessError as e:
         error = e.output.decode("utf-8").strip()
@@ -153,7 +191,7 @@ def run_cargo(runDirectory, command, argsList=[]):
 def cargo_vendor(appDirectory, argsList=[]):
     vendor_dir = os.path.join(appDirectory, "vendor")
     log.info(f"Vendoring Cargo.toml deps to {vendor_dir}")
-    run_cargo(appDirectory, "vendor", argsList + ["--", vendor_dir])
+    run_cargo(appDirectory, "vendor", argsList + ["--", "vendor"])
     return vendor_dir
 
 
@@ -179,10 +217,11 @@ def main():
 
         # remove extracted Rust application source
         try:
+            basename = archive.replace(f".{archive_ext}", "")
             to_remove = os.path.join(outdir, basename)
             shutil.rmtree(to_remove)
         except FileNotFoundError:
-            log.error(f"Could not remove directory not found {to_remove}")
+            log.error(f"Could not remove: Directory not found {to_remove}")
     else:
         log.error(f"Not a valid strategy : \"{args.strategy}\"")
         exit(1)


### PR DESCRIPTION
- Update instructions to use cargo config in spec
- Add ability to use a directory instead of archive
- Use autodetection for directory containing Cargo.toml
- Fix vendor dir for cargo config
- Writes the settings specified by `cargo-vendor` to `cargo_config`
- Logs the recommended example modifications for the spec file to stdout
- Update README.md

---

Tested using obs_scm and standard released tarball packaging. Appears to work pretty well. Additionally the `cargo_config` output will help prevent some work for maintainers in future.