### PR TITLE
Remove insecure archive decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,98 +19,119 @@ of Rust application packages for [openSUSE](https://www.opensuse.org),
 The vendored sources allow building a Rust application using `cargo build`, without requiring
 access to the network.
 
-## Usage for packagers
+## Usage for packagers (with SCM service)
 
 Follow this steps when creating a new RPM package for a Rust application:
 
 1. Add to the `_service` file this snippet:
+
 ```
 <services>
+  <service name="obs_scm" mode="disabled">
+    ...
+  </service>
   <service name="cargo_vendor" mode="disabled">
+    <param name="srcdir">projectname</param>
   </service>
 </services>
 ```
 
-> **Note**:
->
-> It is assumed that the Rust application is distributed as a tarball named
-> `app-0.1.0.tar[.<tar compression>]`, unpacking to `app-0.1.0/`.
-> The `<tar compression>` extension can be specified using the `compression` parameter,
-> and defaults to `gz`.
->
-> `obs-service-cargo_vendor` will autodetect tarball archives of the form `app-0.1.0.tar[.<tar compression>]`,
-> where the RPM packaging uses spec file `app.spec`.
->
-> The archive name can alternatively be specified using service parameter `archive`.
->
-> In some instances a package may be using SCM, in which case a directory is used rather than an archive, `cargo_vendor` can also handle this if archive name and compression args are supplied, eg:
->
-> `<param name="archive">tokei</param>`
->
-> `<param name="archive">tokei</param>`
->
-> `cargo_vendor` will also auto find and use the first directory containing a `Cargo.toml` if the archive args is not used.
-
 2. Run `osc` command locally:
 
 ```
-$ osc service disabledrun
+$ osc service ra
 ```
 
-3. Add the generated tarball to the packages sources:
+3. A set of steps is displayed from this command to guide you in modifying your .spec. An example is:
+
+```
+Your spec file should be modified per the following example:
+
+---BEGIN---
+%global rustflags '-Clink-arg=-Wl,-z,relro,-z,now'
+
+Source1:    vendor.tar.xz
+Source2:    cargo_config
+
+%prep
+%setup -qa1
+mkdir .cargo
+cp %{SOURCE2} .cargo/config
+
+%build
+RUSTFLAGS=%{rustflags} cargo build --release
+
+%install
+RUSTFLAGS=%{rustflags} cargo install --root=%{buildroot}%{_prefix} --path .
+```
+
+4. Add the generated tarball to the packages sources:
+
 ```
 $ osc add vendor.tar.gz
 ```
 
-4. In `app.spec`:
- - include the tarball as a source, along with the cargo_config and the main source tarball:
+5. Perform a local build to confirm the changes work as expected:
+
 ```
-Source0:        app-%{version}.tar.xz
-Source1:        vendor.tar.xz
-Source2:        cargo_config
-```
- - At the `%prep` step, extract the vendor archive inside the app source code:
-```
-%prep
-%setup -q -a1
+$ osc build
 ```
 
-Create a `$CARGO_HOME` directory, including the `config` file in it with the configuration
-for the vendored sources:
+## Manual (without SCM service)
+
+If you are not using SCM, you can use the cargo vendor service manually.
+
+1. Extract your source archive into your working directory.
+
 ```
-mkdir .cargo
-cp %{SOURCE2} .cargo/config
+$ tar -xv archive.tar.xz
 ```
 
-- At the `%build` step, export the previously created `$CARGO_HOME` and use `cargo build`
-to build the application:
+2. Examine the folder name it extracted, IE archive-v1.0.0
+
+3. Set srcdir to match
+
 ```
-cargo build --release # <cargo build options...>
+<services>
+  <service name="cargo_vendor" mode="disabled">
+    <param name="srcdir">archive-v1.0.0</param>
+  </service>
+</services>
 ```
+
+4. Continue from Usage for packagers - Step 2.
+
+Note you will not be able to have a server side cargo vendor service with this configuration, so
+you should keep `mode="disabled"`
 
 ## Options
 
-There are a few options that you can supply to the service. The default behaviour without these options is to autodetect the archive type, and in the case where a directory is found with a `Cargo.toml` in the root, then the default compression of `gzip` is used.
+- `<param name="srcdir">projectname</param>`
 
-- `<param name="strategy">vendor</param>`
-
-The default here is `vendor` which will use `cargo vendor` to fetch the crate dependencies. There are currently no alternatives to `vendor`.
-
-- `<param name="archive">archivename.tar.gz</param>`
-
-The name of the required archive. The option is used in the case where there may be multiple archives available in the package build. This can also be used to specify a directory - useful in the case of using the `obs_scm` service.
+The location to search for the Cargo.toml which we will vendor from. Generally this is your project
+name from the SCM checkout, or the extracted archive top dir, but it may differ depending on your
+configuration.
 
 - `<param name="compression">xz</param>`
 
-The compression to use for the `vendor.tar`. If the option is not supplied it will default to `gz` or the same compression as the source archive. Available compressions are those supported by `tar`.
+The compression to use for the `vendor.tar`. If the option is not supplied it will default to `xz`.
+Available compressions are those supported by `tar`.
+
+- `<param name="strategy">vendor</param>`
+
+The default here is `vendor` which will use `cargo vendor` to fetch the crate dependencies. There
+are currently no alternatives to `vendor`.
 
 #### Example
 
 ```
 <services>
+  <service name="obs_scm" mode="disabled">
+    ...
+  </service>
   <service name="cargo_vendor" mode="disabled">
     <param name="strategy">vendor</param>
-    <param name="archive">some_git_repo</param>
+    <param name="srcdir">projectname</param>
     <param name="compression">xz</param>
   </service>
 </services>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ RUSTFLAGS=%{rustflags} cargo install --root=%{buildroot}%{_prefix} --path .
 4. Add the generated tarball to the packages sources:
 
 ```
-$ osc add vendor.tar.gz
+$ osc add vendor.tar.xz
 ```
 
 5. Perform a local build to confirm the changes work as expected:

--- a/cargo_vendor
+++ b/cargo_vendor
@@ -19,6 +19,10 @@ Rust project locally, by calling:
 
 cargo vendor  <path/to/project/vendor>
 
+This requires a decompressed version of you sources. Either you need to
+provide this manually, or you can use obs_scm to generate this as part
+of the osc services.
+
 obs-service-cargo_vendor will a create vendor tarball, compressed with
 the specified method (default to "gz"), containing the
 vendor/ directory populated by cargo vendor.
@@ -44,18 +48,18 @@ description = __doc__
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(service_name)
 
-DEFAULT_COMPRESSION = "gz"
-
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
 )
 parser.add_argument("--strategy", default="vendor")
-parser.add_argument("--archive")
+parser.add_argument("--srcdir")
 parser.add_argument("--outdir")
-parser.add_argument("--compression")
+parser.add_argument("--compression", default="xz")
 args = parser.parse_args()
 
 outdir = args.outdir
+srcdir = args.srcdir
+compression = args.compression
 
 vendor_example = """
 Your spec file should be modified per the following example:
@@ -82,20 +86,7 @@ WARNING: To avoid cargo install rebuilding the binary in the install stage
          all environment variables must be the same as in the build stage.
 """
 
-
-def get_archive_extension():
-    if args.compression not in tarfile.TarFile.OPEN_METH:
-        log.error(f"The specified compression mode is not supported: \"{args.compression}\"")
-        exit(1)
-
-    if args.compression == "tar":
-        return "tar"
-
-    return "tar." + (args.compression or DEFAULT_COMPRESSION)
-
-
-archive_ext = get_archive_extension()
-vendor_tarname = f"vendor.{archive_ext}"
+vendor_tarname = f"vendor.tar.{compression}"
 
 
 def find_file(path, filename):
@@ -103,71 +94,6 @@ def find_file(path, filename):
         if filename in files:
             print(os.path.join(root, filename))
             return os.path.join(root, filename)
-
-
-def archive_autodetect():
-    """ Find the most likely candidate file that contains a Rust project.
-        For most Rust applications this will be app-x.y.z.tar[.<tar compression>].
-        Use the name of the .spec file as the stem for the archive to detect.
-    """
-    log.info(f"Autodetecting archive since no archive param provided in _service")
-    cwd = Path.cwd()
-    # first .spec under cwd or None
-    spec = next(reversed(sorted(Path(cwd).glob("*.spec"))), None)
-    if not spec:
-        log.error(f"Archive autodetection found no spec file under {cwd}")
-        exit(1)
-    else:
-        spec_dir = spec.parent  # typically the same as cwd
-        # highest sorted archive under spec_dir
-        pattern = f"{spec.stem}*.{archive_ext}"
-        archive = next(reversed(sorted(Path(spec_dir).glob(pattern))), None)
-    if not archive:
-        archive = find_file(cwd, "Cargo.toml")
-        app_dir = os.path.basename(os.path.normpath(os.path.dirname(archive)))
-        if app_dir:
-            return app_dir
-        else:
-            log.error(f"Archive autodetection found no matching archive under {cwd}")
-            exit(1)
-    else:
-        log.info(f"Archive autodetected at {archive}")
-        # Check that app.spec Version: directive value
-        # is a substring of detected archive filename
-        # Warn if there is disagreement between the versions.
-        pattern = re.compile(r"^Version:\s+([\S]+)$", re.IGNORECASE)
-        with spec.open(encoding="utf-8") as f:
-            for line in f:
-                versionmatch = pattern.match(line)
-                if versionmatch:
-                    version = versionmatch.groups(0)[0]
-            if not version:
-                log.warning(f"Version not found in {spec.name}")
-            else:
-                if not (version in archive.name):
-                    log.warning(
-                        f"Version {version} in {spec.name} does not match {archive.name}"
-                    )
-        return str(archive.name)  # return string not PosixPath
-
-
-archive = args.archive or archive_autodetect()
-log.info(f"Using archive {archive}")
-
-def extract(filename, dir):
-    if filename.endswith(f".{archive_ext}"):
-        tar = tarfile.open(filename)
-        tar.extractall(path=dir)
-        tar.close()
-    else:
-        cargo_toml_path = find_file(filename, "Cargo.toml")
-        if cargo_toml_path:
-            log.info(f"Archive {filename} is a directory containing Cargo.toml")
-            log.info(f"Copying {filename} in to {dir}")
-            shutil.copytree(filename, dir+'/'+filename)
-        else:
-            log.info(f"Unsupported archive file format for {filename}")
-            exit(1)
 
 
 def run_cargo(runDirectory, command, argsList=[]):
@@ -198,10 +124,10 @@ def cargo_vendor(appDirectory, argsList=[]):
 def main():
     log.info(f"Running OBS Source Service: {service_name}")
 
-    log.info(f"Extracting {archive} to {outdir}")
-    extract(archive, outdir)
+    log.info(f"Searching for Cargo.toml in {srcdir}")
+    log.info(f"Current work dir {os.getcwd()}")
 
-    cargo_toml_path = find_file(outdir, "Cargo.toml")
+    cargo_toml_path = find_file(srcdir, "Cargo.toml")
     if cargo_toml_path:
         app_dir = os.path.dirname(cargo_toml_path)
         log.info(f"Detected Rust app directory: {app_dir}")
@@ -212,16 +138,8 @@ def main():
     if args.strategy == "vendor":
         vendor_dir = cargo_vendor(appDirectory=app_dir)
         vendor_tarfile = os.path.join(outdir, vendor_tarname)
-        with tarfile.open(vendor_tarfile, "w:" + args.compression) as tar:
+        with tarfile.open(vendor_tarfile, f"w:{compression}") as tar:
             tar.add(vendor_dir, arcname=("vendor"))
-
-        # remove extracted Rust application source
-        try:
-            basename = archive.replace(f".{archive_ext}", "")
-            to_remove = os.path.join(outdir, basename)
-            shutil.rmtree(to_remove)
-        except FileNotFoundError:
-            log.error(f"Could not remove: Directory not found {to_remove}")
     else:
         log.error(f"Not a valid strategy : \"{args.strategy}\"")
         exit(1)


### PR DESCRIPTION
As part of the process to integrate this tool to obs, a security
was undertaken at SUSE. It was highlighted that the use of Tarfile
is unsafe, and may be exploitable via untrusted tar archives from
a malicious party. A number of suggestions were discussed. Python
has been attempting to develop a safetar module, but it's not
ready yet. Another option was attempting a chroot with nsjail.
However, this would mean manually calling tar with subprocess,
leading to other complications, and nsjail has about 3000 tunables
which unless configured properly could still be an issue.

Instead, a simpler approach exists - it's not our problem. We only
need to perform cargo vendor in a source directory. obs_scm as part
of it's operation already creates a directory like this that we
can use. It's not only faster (saving a decompression step), but
simpler, and completely avoids all security issues associated with
tar file decompression.

If a project is not able to use obs_scm, and would need decompression
this becomes "not our problem" - it would be the task of a seperate
obs module to provide a decompression service to allow the source
to be fed to cargo vendor.

Of course, this is a breaking change as we remove a number of
options, and add others, but it's a change that leads toward
inclusion in OBS as a true server side service. I have already tested
this with some projects and can confirm it works.

Author: William Brown <wbrown at suse.de>