### PR TITLE
Cleanup vendor folder after compression

### DIFF
--- a/cargo_vendor
+++ b/cargo_vendor
@@ -138,11 +138,20 @@ def main():
     if args.strategy == "vendor":
         vendor_dir = cargo_vendor(appDirectory=app_dir)
         vendor_tarfile = os.path.join(outdir, vendor_tarname)
+        log.info("Starting compression ...")
         with tarfile.open(vendor_tarfile, f"w:{compression}") as tar:
             tar.add(vendor_dir, arcname=("vendor"))
+        # Complete, so cleanup the vendor folder. This is needed as obs_scm + compress
+        # will on subsequent runs, put the vendor folder in the mail tar AND into
+        # our vendor.tar.xz.
+        #
+        # This is not a greater cost, as cargo vendor will always download anyway.
+        log.info(f"Cleaning up {vendor_dir} ...")
+        shutil.rmtree(vendor_dir)
     else:
         log.error(f"Not a valid strategy : \"{args.strategy}\"")
         exit(1)
+    log.info(f"Success")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When calling cargo_vendor, we leave a vendor directory inside
of the source folder. During a typical source run the modules
we have are:

    obs_scm
    compress
    cargo_vendor

The issue is that when we run this service *again*, the previous
copy of "vendor" remains in our checked out source, which means
that we end up with vendor inside both the compressed source
tar AND our vendor.tar.

This change cleans up the vendor folder after we complete compression
to avoid this situation, making the output tars cleaner.

Fixes #12