### PR TITLE
utils: exit vendor step if no dependencies found

### DIFF
--- a/cargo/src/utils/mod.rs
+++ b/cargo/src/utils/mod.rs
@@ -166,7 +166,11 @@ pub fn process_src(args: &Opts, prjdir: &Path) -> io::Result<()> {
         vendor_dir.as_ref(),
     ];
 
-    vendor::compress(outdir, prjdir, &paths_to_archive, compression)?;
+    if vendor_dir.exists() {
+        vendor::compress(outdir, prjdir, &paths_to_archive, compression)?;
+    } else {
+        info!("😌 No dependencies, no need to vendor!");
+    }
 
     // And we're golden!
     Ok(())


### PR DESCRIPTION
we check if there exists a `vendor/` directory.

if there is none, it means it has no dependencies to vendor