### PR TITLE
20231117 fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Use only `cargotoml` in situations where you need to also vendor a subcrate. Thi
 > </services>
 > ```
 
+> [!IMPORTANT]
+> If a project uses a workspace, you don't actually need to do this unless the workspace manifest is part of a subproject.
+
 Once you are ready, run the following command locally:
 
 ```bash
@@ -77,12 +80,37 @@ osc add vendor.tar.zst
 ```
 
 > [!IMPORTANT]
-> If using `cargotoml`, the vendored tarball is named after their parent directories e.g. `rust/pv/Cargo.toml` -> `pv.vendor.tar.zst`,
-> and has its own `cargo_config` file as well e.g. `rust/pv/Cargo.toml` -> `pv_cargo_config`.
-
-> [!IMPORTANT]
 > Some Rust software such as the infamous https://github.com/elliot40404/bonk do not have any dependencies so they may not generate a vendored tarball.
 > The service will give you an output of information about it by checking the manifest file.
+
+# What is inside `vendor.tar.<zst,gz,xz>`?
+
+The files inside the vendored tarball contains the following:
+- a lockfile `Cargo.lock`
+- a `.cargo/config`
+- the crates that were fetched during the vendor process.
+
+When extracted, it will have the following paths when extracted.
+
+```
+.
+├── .cargo/
+│   └── config
+├── Cargo.lock
+└── vendor/
+```
+
+This means, a `%prep` section may look like this
+
+```
+%prep
+%autosetup -a1
+```
+
+No need to copy a `cargo_config` or a lockfile to somewhere else or add it as part of the sources in the specfile. *They are all part of the vendored tarball now*.
+
+> [!NOTE]
+> If desired, you may use this knowledge for weird projects that have weird build configurations. 
 
 # Parameters
 
@@ -94,7 +122,7 @@ Usage: cargo_vendor [OPTIONS] --src <SRC> --outdir <OUTDIR>
 Options:
       --src <SRC>                  Where to find sources. Source is either a directory or a source tarball AND cannot be both. [aliases: srctar, srcdir]
       --compression <COMPRESSION>  What compression algorithm to use. [default: zst] [possible values: gz, xz, zst]
-      --tag <TAG>                  Tag some files for multi-vendor and multi-cargo_config projects
+      --tag <TAG>                  Tag some files for multi-vendor and multi-cargo_config projects. DEPRECATED. DO NOT USE.
       --cargotoml <CARGOTOML>      Other cargo manifest files to sync with during vendor
       --update <UPDATE>            Update dependencies or not [default: true] [possible values: true, false]
       --outdir <OUTDIR>            Where to output vendor.tar* and cargo_config

--- a/cargo/src/bin/cargo_vendor.rs
+++ b/cargo/src/bin/cargo_vendor.rs
@@ -79,6 +79,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("🎢 Starting OBS Service Cargo Vendor.");
     debug!(?args);
 
+    if args.tag.is_some() {
+        error!("⚠️  tags are no longer supported for vendoring.");
+        eprintln!(
+            r#"
+When you have multiple Cargo.toml's in a project, you can specify them with
+
+    <param name=\"cargotoml\">first/Cargo.toml</param>"
+    <param name=\"cargotoml\">second/Cargo.toml</param>"
+
+This will create a single vendor.tar that will work with both projects.
+"#
+        );
+    }
+
+    warn!("⚠️  Cargo Vendor has been rewritten in rust!");
+    eprintln!(
+        r#"
+This rewrite introduces some small changes to how vendoring functions for your package.
+
+* cargo_config is no longer created - it's part of the vendor.tar now
+    * You can safely remove lines related to cargo_config from your spec file
+
+* multiple cargotoml files can be specified and share a single vendor.tar
+    * If multiple cargo.toml files are present update does not work. This is a known
+      limitation of the process
+
+* cargo_audit is now part of cargo_vendor, meaning you don't have to configure it separately
+
+"#
+    );
+
     match args.src.run_vendor(&args) {
         Ok(_) => Ok(()),
         Err(err) => {

--- a/cargo/src/utils/mod.rs
+++ b/cargo/src/utils/mod.rs
@@ -88,7 +88,8 @@ pub fn process_src(args: &Opts, prjdir: &Path) -> Result<(), OBSCargoError> {
     // Setup some common paths we'll use from here out.
     let outdir = args.outdir.to_owned();
     let cargo_lock = prjdir.join("Cargo.lock");
-    let cargo_config = prjdir.join("cargo_config");
+    // let cargo_config = prjdir.join("cargo_config");
+    let cargo_config = prjdir.join(".cargo/config");
     let vendor_dir = prjdir.join("vendor");
     let update = args.update;
 

--- a/cargo/src/utils/mod.rs
+++ b/cargo/src/utils/mod.rs
@@ -67,7 +67,7 @@ pub fn process_src(args: &Opts, prjdir: &Path) -> Result<(), OBSCargoError> {
     let mut manifest_files: Vec<PathBuf> = if !args.cargotoml.is_empty() {
         debug!("Using manually specified Cargo.toml files.");
         debug!(?args.cargotoml);
-        args.cargotoml.iter().map(|p| p.into()).collect()
+        args.cargotoml.iter().map(|p| prjdir.join(p)).collect()
     } else {
         debug!("Assuming Cargo.toml in root of the projectdir");
         vec![prjdir.join("Cargo.toml")]

--- a/cargo/src/utils/mod.rs
+++ b/cargo/src/utils/mod.rs
@@ -136,6 +136,9 @@ pub fn process_src(args: &Opts, prjdir: &Path) -> Result<(), OBSCargoError> {
             return Ok(());
         }
 
+        // Then we update `has_deps` to be the same as `should_vendor`.
+        hasdeps = should_vendor;
+
         if update {
             vendor::update(prjdir, &first_manifest)?
         } else {

--- a/cargo/src/utils/mod.rs
+++ b/cargo/src/utils/mod.rs
@@ -148,11 +148,7 @@ pub fn process_src(args: &Opts, prjdir: &Path) -> Result<(), OBSCargoError> {
         }
         // Okay, we are ready to go now.
     } else if update {
-        warn!("⚠️  Unable to update when multiple Cargo.toml files are specified.");
-        return Err(OBSCargoError::new(
-            OBSCargoErrorKind::VendorError,
-            "Unable to update when multiple Cargo.toml files are specified.".to_string(),
-        ));
+        warn!("⚠️  Unable to update when multiple Cargo.toml files are specified. Ignoring `update` parameter with value set to `{}`.", update);
     }
 
     // Audit the Cargo.lock file.

--- a/cargo/src/vendor.rs
+++ b/cargo/src/vendor.rs
@@ -69,6 +69,19 @@ pub fn vendor(
         )
     })?;
 
+    match cargo_config.as_ref().parent() {
+        Some(p_path) => {
+            fs::create_dir_all(p_path).map_err(|err| {
+                error!(?err, "Failed to create parent dir for cargo config");
+                OBSCargoError::new(
+                    OBSCargoErrorKind::VendorError,
+                    "failed to create parent dir for cargo config".to_string(),
+                )
+            })?;
+        }
+        _ => {}
+    }
+
     let mut file_cargo_config = fs::File::create(cargo_config.as_ref()).map_err(|err| {
         error!(?err, "Failed to create file for cargo config");
         OBSCargoError::new(


### PR DESCRIPTION
Fixes #59 - This fixes multi-toml vendor when a workspace is not present, adds an error if --tag is used, and automatically sets up .cargo/config for projects meaning that spec files can be tidier. 